### PR TITLE
PHPStan für statische Code-Analyse einrichten

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,8 @@
         }
     },
     "require-dev": {
+        "phpstan/phpstan": "*",
+        "phpstan/phpstan-symfony": "*",
         "phpunit/phpunit": "^12",
         "symfony/browser-kit": "7.4.*",
         "symfony/phpunit-bridge": "^7.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c32dfd91ed080677d11b1ae5ddd1a93",
+    "content-hash": "8192950397427ac0c2c8a433d2896812",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4741,6 +4741,133 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.46",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-01T09:25:14+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-symfony",
+            "version": "2.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-symfony.git",
+                "reference": "9b85ab476969b87bbe2253b69e265a9359b2f395"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/9b85ab476969b87bbe2253b69e265a9359b2f395",
+                "reference": "9b85ab476969b87bbe2253b69e265a9359b2f395",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.13"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<3.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "psr/container": "1.1.2",
+                "symfony/config": "^5.4 || ^6.1",
+                "symfony/console": "^5.4 || ^6.1",
+                "symfony/dependency-injection": "^5.4 || ^6.1",
+                "symfony/form": "^5.4 || ^6.1",
+                "symfony/framework-bundle": "^5.4 || ^6.1",
+                "symfony/http-foundation": "^5.4 || ^6.1",
+                "symfony/messenger": "^5.4",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/serializer": "^5.4",
+                "symfony/service-contracts": "^2.2.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukáš Unger",
+                    "email": "looky.msc@gmail.com",
+                    "homepage": "https://lookyman.net"
+                }
+            ],
+            "description": "Symfony Framework extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-symfony/issues",
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.15"
+            },
+            "time": "2026-02-26T10:15:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,85 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method Imagine\\Image\\Palette\\Color\\ColorInterface\:\:getBlue\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: src/Bfs/Graph/Point.php
+
+		-
+			message: '#^Call to an undefined method Imagine\\Image\\Palette\\Color\\ColorInterface\:\:getGreen\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: src/Bfs/Graph/Point.php
+
+		-
+			message: '#^Call to an undefined method Imagine\\Image\\Palette\\Color\\ColorInterface\:\:getRed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Bfs/Graph/Point.php
+
+		-
+			message: '#^Call to an undefined method Imagine\\Image\\Palette\\Color\\ColorInterface\:\:getGreen\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Bfs/Graph/Scale.php
+
+		-
+			message: '#^Call to an undefined method Imagine\\Image\\Palette\\Color\\ColorInterface\:\:getRed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Bfs/Graph/Scale.php
+
+		-
+			message: '#^Method App\\Bfs\\Station\\Loader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Bfs/Station/Loader.php
+
+		-
+			message: '#^Method App\\Bfs\\Station\\LoaderInterface\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Bfs/Station/LoaderInterface.php
+
+		-
+			message: '#^Method App\\Bfs\\Website\\StationLinkExtractor\:\:parseStationLinks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Bfs/Website/StationLinkExtractor.php
+
+		-
+			message: '#^Method App\\Bfs\\Website\\StationLinkExtractorInterface\:\:parseStationLinks\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Bfs/Website/StationLinkExtractorInterface.php
+
+		-
+			message: '#^Call to an undefined method Caldera\\LuftModel\\Model\\Station\:\:setOperator\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Bfs/Website/StationPageParser.php
+
+		-
+			message: '#^Method App\\Command\\AbstractCommand\:\:cacheStationList\(\) has parameter \$stationList with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Command/AbstractCommand.php
+
+		-
+			message: '#^Method App\\Command\\AbstractCommand\:\:getStationList\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Command/AbstractCommand.php
+
+		-
+			message: '#^Method App\\Command\\Luft\\FetchCommand\:\:processStationList\(\) has parameter \$stationList with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Command/Luft/FetchCommand.php
+
+		-
+			message: '#^Method App\\Command\\Luft\\FetchCommand\:\:processStationList\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Command/Luft/FetchCommand.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/phpstan/phpstan-symfony/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 6
+    paths:
+        - src
+    symfony:
+        containerXmlPath: var/cache/dev/App_KernelDevDebugContainer.xml

--- a/src/Bfs/Station/Loader.php
+++ b/src/Bfs/Station/Loader.php
@@ -16,6 +16,13 @@ class Loader implements LoaderInterface
     }
     public function load(): array
     {
+        $stationLinks = $this->linkExtractor->parseStationLinks();
+        $stationList = [];
 
+        foreach ($stationLinks as $stationLink) {
+            $stationList[] = $this->pageParser->parse($stationLink);
+        }
+
+        return $stationList;
     }
 }


### PR DESCRIPTION
## Summary
- PHPStan und phpstan-symfony als Dev-Abhängigkeit installiert
- Level 6 konfiguriert mit Baseline für 25 bestehende Fehler
- `Loader::load()` implementiert (war leer, erzeugte non-ignorable Fehler)

## Test plan
- [x] PHPStan läuft fehlerfrei mit Baseline
- [x] Alle 62 Unit-Tests bestanden

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)