### PR TITLE
PHP-CS-Fixer für einheitlichen Code-Stil einrichten

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(php:*)",
+      "Bash(composer show:*)",
+      "Bash(composer update:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Bash(composer require:*)",
+      "Bash(composer install:*)",
+      "Bash(gh auth:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@
 /phpunit.xml
 .phpunit.result.cache
 ###< phpunit/phpunit ###
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+    ->notPath([
+        'config/bundles.php',
+        'config/reference.php',
+    ])
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         }
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.94",
         "phpstan/phpstan": "*",
         "phpstan/phpstan-symfony": "*",
         "phpunit/phpunit": "^12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8192950397427ac0c2c8a433d2896812",
+    "content-hash": "c32ccb0ea5cd2fcd26a868a5036dcd9b",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4565,6 +4565,504 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.94.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.3",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.5",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.3",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.6",
+                "react/event-loop": "^1.5",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.33",
+                "symfony/polyfill-php80": "^1.33",
+                "symfony/polyfill-php81": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.7.1",
+                "infection/infection": "^0.32.3",
+                "justinrainbow/json-schema": "^6.6.4",
+                "keradus/cli-executor": "^2.3",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.7",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.7",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.51",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.4",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.1"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/**/Internal/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.94.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-20T16:13:53+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -5304,6 +5802,532 @@
                 }
             ],
             "time": "2026-04-03T05:26:42+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.7"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-12-23T15:25:20+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6391,6 +7415,72 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/phpunit-bridge/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v7.4.8"
             },
             "funding": [
                 {

--- a/src/Bfs/Cache/CacheInterface.php
+++ b/src/Bfs/Cache/CacheInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Cache;
 

--- a/src/Bfs/Coordinate/Converter.php
+++ b/src/Bfs/Coordinate/Converter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Coordinate;
 
@@ -6,7 +8,6 @@ class Converter
 {
     private function __construct()
     {
-
     }
 
     public static function convert(string $coordinateString): Coord

--- a/src/Bfs/Coordinate/Coord.php
+++ b/src/Bfs/Coordinate/Coord.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Coordinate;
 
@@ -6,7 +8,6 @@ class Coord
 {
     public function __construct(private readonly float $latitude, private readonly float $longitude)
     {
-
     }
 
     public function getLatitude(): float

--- a/src/Bfs/Exception/NoPointException.php
+++ b/src/Bfs/Exception/NoPointException.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Exception;
 
 class NoPointException extends \Exception
 {
-
 }

--- a/src/Bfs/Fetcher/ValueFetcher.php
+++ b/src/Bfs/Fetcher/ValueFetcher.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Fetcher;
 

--- a/src/Bfs/Fetcher/ValueFetcherInterface.php
+++ b/src/Bfs/Fetcher/ValueFetcherInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Fetcher;
 

--- a/src/Bfs/Graph/CurrentDateTime.php
+++ b/src/Bfs/Graph/CurrentDateTime.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -15,7 +17,6 @@ class CurrentDateTime
 
     private function __construct()
     {
-
     }
 
     public static function calculate(ImageInterface $image): ?Carbon

--- a/src/Bfs/Graph/HourRange.php
+++ b/src/Bfs/Graph/HourRange.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -13,7 +15,6 @@ class HourRange
 
     private function __construct()
     {
-
     }
 
     public static function calculate(ImageInterface $image): HourRangeModel

--- a/src/Bfs/Graph/HourRangeModel.php
+++ b/src/Bfs/Graph/HourRangeModel.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -6,7 +8,6 @@ class HourRangeModel
 {
     public function __construct(private readonly int $startHour, private readonly int $endHour)
     {
-
     }
 
     public function getStartHour(): int

--- a/src/Bfs/Graph/Maintenance.php
+++ b/src/Bfs/Graph/Maintenance.php
@@ -1,9 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
 use Imagine\Image\ImageInterface;
 use Imagine\Image\Point as ImaginePoint;
+
 class Maintenance
 {
     private const array POINT_LISTS = [
@@ -17,12 +20,11 @@ class Maintenance
             [417, 120],
             [247, 149],
             [417, 149],
-        ]
+        ],
     ];
 
     private function __construct()
     {
-
     }
 
     public static function isMaintenance(ImageInterface $image): bool
@@ -31,7 +33,7 @@ class Maintenance
 
         $edgeCounter = 0;
 
-        foreach (self::POINT_LISTS as $pointList)
+        foreach (self::POINT_LISTS as $pointList) {
             foreach ($pointList as $point) {
                 $imagePoint = new ImaginePoint($point[0], $point[1]);
 
@@ -43,6 +45,7 @@ class Maintenance
                     return true;
                 }
             }
+        }
 
         return false;
     }

--- a/src/Bfs/Graph/MaxUvIndex.php
+++ b/src/Bfs/Graph/MaxUvIndex.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -8,7 +10,6 @@ class MaxUvIndex
 {
     private function __construct()
     {
-
     }
 
     public static function detectMaxUvIndex(ImageInterface $image): float

--- a/src/Bfs/Graph/Point.php
+++ b/src/Bfs/Graph/Point.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -11,7 +13,6 @@ class Point
 {
     private function __construct()
     {
-
     }
 
     public static function detectCurrentPoint(ImageInterface $image): ImaginePoint
@@ -22,7 +23,7 @@ class Point
 
         for ($x = 575; $x >= 0; --$x) {
             try {
-                $point = new ImaginePoint($x,  $height - 49);
+                $point = new ImaginePoint($x, $height - 49);
             } catch (InvalidArgumentException $invalidArgumentException) {
                 throw new NoPointException('Could not find current point in image.');
             }
@@ -51,7 +52,7 @@ class Point
         }
 
         try {
-            $point =  new ImaginePoint($x, $y);
+            $point = new ImaginePoint($x, $y);
         } catch (InvalidArgumentException $invalidArgumentException) {
             throw new NoPointException('Could not find current point in image.');
         }

--- a/src/Bfs/Graph/Scale.php
+++ b/src/Bfs/Graph/Scale.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -18,7 +20,6 @@ class Scale
 
     private function __construct()
     {
-
     }
 
     public static function sizeY(ImageInterface $image): int
@@ -32,7 +33,7 @@ class Scale
             $point = new Point(self::Y_PADDING_LEFT, $y);
             $color = $image->getColorAt($point);
 
-            if ($color->getRed() === self::Y_THRESHOLD && $color->getGreen() === self::Y_THRESHOLD && $color->getRed() === self::Y_THRESHOLD) {
+            if (self::Y_THRESHOLD === $color->getRed() && self::Y_THRESHOLD === $color->getGreen() && self::Y_THRESHOLD === $color->getRed()) {
                 ++$counter;
 
                 $y -= 5; // jump five pixels to avoid detecting some grey artifacts as scale again
@@ -53,7 +54,7 @@ class Scale
             $point = new Point($x, self::X_PADDING_TOP);
             $color = $image->getColorAt($point);
 
-            if ($color->getRed() === self::X_THRESHOLD && $color->getGreen() === self::X_THRESHOLD && $color->getRed() === self::X_THRESHOLD) {
+            if (self::X_THRESHOLD === $color->getRed() && self::X_THRESHOLD === $color->getGreen() && self::X_THRESHOLD === $color->getRed()) {
                 ++$counter;
 
                 $x -= 5; // jump five pixels to avoid detecting some grey artifacts as scale again

--- a/src/Bfs/Graph/StepSize.php
+++ b/src/Bfs/Graph/StepSize.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Graph;
 
@@ -8,7 +10,6 @@ class StepSize
 {
     private function __construct()
     {
-
     }
 
     public static function detectStepSize(ImageInterface $image): float

--- a/src/Bfs/Station/Loader.php
+++ b/src/Bfs/Station/Loader.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Station;
 
@@ -9,11 +11,10 @@ class Loader implements LoaderInterface
 {
     public function __construct(
         private readonly StationLinkExtractorInterface $linkExtractor,
-        private readonly StationPageParserInterface $pageParser
-    )
-    {
-
+        private readonly StationPageParserInterface $pageParser,
+    ) {
     }
+
     public function load(): array
     {
         $stationLinks = $this->linkExtractor->parseStationLinks();

--- a/src/Bfs/Station/LoaderInterface.php
+++ b/src/Bfs/Station/LoaderInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Station;
 

--- a/src/Bfs/Station/Namer.php
+++ b/src/Bfs/Station/Namer.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Station;
 
-use App\Bfs\Coordinate\Coord;
 use App\Bfs\Website\StationModel;
 
 class Namer
@@ -25,7 +26,6 @@ class Namer
 
     private function __construct()
     {
-
     }
 
     public static function generate(StationModel $model): string

--- a/src/Bfs/Website/PageLinkModel.php
+++ b/src/Bfs/Website/PageLinkModel.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Website;
 
@@ -6,7 +8,6 @@ class PageLinkModel
 {
     public function __construct(private readonly string $url, private readonly string $caption)
     {
-
     }
 
     public function getUrl(): string

--- a/src/Bfs/Website/StationLinkExtractor.php
+++ b/src/Bfs/Website/StationLinkExtractor.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Website;
 
@@ -45,10 +47,10 @@ class StationLinkExtractor implements StationLinkExtractorInterface
             return $url;
         }
 
-        if ($url !== '' && $url[0] !== '/') {
-            $url = '/' . $url;
+        if ('' !== $url && '/' !== $url[0]) {
+            $url = '/'.$url;
         }
 
-        return self::HOSTNAME . $url;
+        return self::HOSTNAME.$url;
     }
 }

--- a/src/Bfs/Website/StationLinkExtractorInterface.php
+++ b/src/Bfs/Website/StationLinkExtractorInterface.php
@@ -1,11 +1,13 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Website;
 
 interface StationLinkExtractorInterface
 {
-    const PAGE_URL = 'https://www.bfs.de/DE/themen/opt/uv/uv-index/aktuelle-tagesverlaeufe/aktuelle-tagesverlaeufe.html';
-    const HOSTNAME = 'https://www.bfs.de/';
+    public const PAGE_URL = 'https://www.bfs.de/DE/themen/opt/uv/uv-index/aktuelle-tagesverlaeufe/aktuelle-tagesverlaeufe.html';
+    public const HOSTNAME = 'https://www.bfs.de/';
 
     public function parseStationLinks(): array;
 }

--- a/src/Bfs/Website/StationModel.php
+++ b/src/Bfs/Website/StationModel.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Website;
 

--- a/src/Bfs/Website/StationPageParser.php
+++ b/src/Bfs/Website/StationPageParser.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Website;
 
@@ -10,7 +12,6 @@ class StationPageParser implements StationPageParserInterface
 {
     public function __construct()
     {
-
     }
 
     public function parse(string $url): StationModel

--- a/src/Bfs/Website/StationPageParserInterface.php
+++ b/src/Bfs/Website/StationPageParserInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Bfs\Website;
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Command;
 
@@ -18,6 +20,7 @@ abstract class AbstractCommand extends Command
     {
         $cache = $this->createCache();
         $item = $cache->getItem(CacheInterface::CACHE_KEY);
+
         return $item->get();
     }
 

--- a/src/Command/Luft/FetchCommand.php
+++ b/src/Command/Luft/FetchCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Command\Luft;
 
@@ -38,6 +40,7 @@ class FetchCommand extends AbstractCommand
 
         if (!$stationList) {
             $io->error('No station list found in cache. Please load cache before fetching values.');
+
             return Command::FAILURE;
         }
 
@@ -53,7 +56,6 @@ class FetchCommand extends AbstractCommand
 
         /** @var StationModel $station */
         foreach ($stationList as $station) {
-
             try {
                 $value = $this->valueFetcher->fromStation($station);
             } catch (\Exception $exception) {
@@ -73,14 +75,14 @@ class FetchCommand extends AbstractCommand
         if ($output->isVerbose()) {
             $io->progressFinish();
 
-            $io->table(['Station Code', 'Station Title', 'Date Time', 'UV Index'], array_map(function(Value $value) use ($stationList): array
-            {
+            $io->table(['Station Code', 'Station Title', 'Date Time', 'UV Index'], array_map(function (Value $value) use ($stationList): array {
                 $stationTitle = $stationList[$value->getStationCode()]->getTitle();
+
                 return [
                     $value->getStationCode(),
                     $stationTitle,
                     $value->getDateTime()->format('Y-m-d H:i:s'),
-                    $value->getValue()
+                    $value->getValue(),
                 ];
             }, $valueList));
         }

--- a/src/Command/Station/LoadCommand.php
+++ b/src/Command/Station/LoadCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Command\Station;
 

--- a/src/Command/StationCache/ListCommand.php
+++ b/src/Command/StationCache/ListCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Command\StationCache;
 
@@ -24,14 +26,14 @@ class ListCommand extends AbstractCommand
 
         $io->info(sprintf('There are %d stations saved in cache', count($stationList)));
 
-        $io->table(['Station Code', 'Title', 'Latitude', 'Longitude', 'Url', 'Image'], array_map(function(StationModel $station): array {
+        $io->table(['Station Code', 'Title', 'Latitude', 'Longitude', 'Url', 'Image'], array_map(function (StationModel $station): array {
             return [
                 $station->getStationCode(),
                 $station->getTitle(),
                 $station->getLatitude(),
                 $station->getLongitude(),
                 $station->getBfsPageUrl(),
-                $station->getCurrentImageUrl()
+                $station->getCurrentImageUrl(),
             ];
         }, $stationList));
 

--- a/src/Command/StationCache/SaveCommand.php
+++ b/src/Command/StationCache/SaveCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Command\StationCache;
 
@@ -23,8 +25,7 @@ class SaveCommand extends AbstractCommand
     public function __construct(
         private readonly StationLinkExtractorInterface $linkExtractor,
         private readonly StationPageParserInterface $pageParser,
-    )
-    {
+    ) {
         parent::__construct();
     }
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,16 @@
 {
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.94",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.39",
+            "ref": "97aaf9026490db73b86c23d49e5774bc89d2b232"
+        },
+        "files": [
+            ".php-cs-fixer.dist.php"
+        ]
+    },
     "liip/imagine-bundle": {
         "version": "2.12",
         "recipe": {
@@ -14,6 +26,15 @@
     },
     "luft-jetzt/luft-api-bundle": {
         "version": "0.6"
+    },
+    "phpstan/phpstan": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        }
     },
     "phpunit/phpunit": {
         "version": "9.6",

--- a/tests/Unit/Coordinate/ConverterTest.php
+++ b/tests/Unit/Coordinate/ConverterTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Coordinate;
 

--- a/tests/Unit/Coordinate/CoordTest.php
+++ b/tests/Unit/Coordinate/CoordTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Coordinate;
 

--- a/tests/Unit/Fetcher/ValueFetcherTest.php
+++ b/tests/Unit/Fetcher/ValueFetcherTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Fetcher;
 
@@ -39,67 +41,67 @@ class ValueFetcherTest extends TestCase
     {
         return [
             [
-                __DIR__ . '/../../graph/boesel.png',
+                __DIR__.'/../../graph/boesel.png',
                 2.7,
                 self::createCarbon(9, 3),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/friedrichshafen1.png',
+                __DIR__.'/../../graph/friedrichshafen1.png',
                 0.9,
                 self::createCarbon(10, 0),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/friedrichshafen2.png',
+                __DIR__.'/../../graph/friedrichshafen2.png',
                 0.6,
                 self::createCarbon(20, 58),
                 self::createCarbon(21, 5),
             ],
             [
-                __DIR__ . '/../../graph/hamburg1.png',
+                __DIR__.'/../../graph/hamburg1.png',
                 3,
                 self::createCarbon(17, 50),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/hamburg2.png',
+                __DIR__.'/../../graph/hamburg2.png',
                 4.2,
                 self::createCarbon(9, 54),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/lueneburg1.png',
+                __DIR__.'/../../graph/lueneburg1.png',
                 0.6,
                 self::createCarbon(18, 10),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/lueneburg2.png',
+                __DIR__.'/../../graph/lueneburg2.png',
                 5.3,
                 self::createCarbon(14, 9),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/lueneburg3.png',
+                __DIR__.'/../../graph/lueneburg3.png',
                 4.6,
                 self::createCarbon(15, 9),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/lueneburg4.png',
+                __DIR__.'/../../graph/lueneburg4.png',
                 5.4,
                 self::createCarbon(15, 0),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/schneefernhaus1.png',
+                __DIR__.'/../../graph/schneefernhaus1.png',
                 4.4,
                 self::createCarbon(9, 50),
                 self::createCarbon(9, 3),
             ],
             [
-                __DIR__ . '/../../graph/schneefernhaus2.png',
+                __DIR__.'/../../graph/schneefernhaus2.png',
                 1.3,
                 self::createCarbon(15, 10),
                 self::createCarbon(9, 3),
@@ -123,8 +125,8 @@ class ValueFetcherTest extends TestCase
     public static function maintenanceFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/sanktaugustin.png'],
-            [__DIR__ . '/../../graph/hamburg3.png'],
+            [__DIR__.'/../../graph/sanktaugustin.png'],
+            [__DIR__.'/../../graph/hamburg3.png'],
         ];
     }
 
@@ -144,7 +146,7 @@ class ValueFetcherTest extends TestCase
     public static function emptyFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/melpitz.png'],
+            [__DIR__.'/../../graph/melpitz.png'],
         ];
     }
 

--- a/tests/Unit/Graph/CurrentDateTimeTest.php
+++ b/tests/Unit/Graph/CurrentDateTimeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -23,26 +25,26 @@ class CurrentDateTimeTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/boesel.png', self::createDateTime()->setTime(9, 3)],
-            [__DIR__ . '/../../graph/friedrichshafen1.png', self::createDateTime()->setTime(10, 0)],
-            [__DIR__ . '/../../graph/friedrichshafen2.png', self::createDateTime()->setTime(20, 58)],
-            [__DIR__ . '/../../graph/hamburg1.png', self::createDateTime()->setTime(17, 50)],
-            [__DIR__ . '/../../graph/hamburg2.png', self::createDateTime()->setTime(9, 54)],
-            [__DIR__ . '/../../graph/lueneburg1.png', self::createDateTime()->setTime(18, 10)],
-            [__DIR__ . '/../../graph/lueneburg2.png', self::createDateTime()->setTime(14, 9)],
-            [__DIR__ . '/../../graph/lueneburg3.png', self::createDateTime()->setTime(15, 9)],
-            [__DIR__ . '/../../graph/lueneburg4.png', self::createDateTime()->setTime(15, 0)],
-            [__DIR__ . '/../../graph/lueneburg5.png', self::createDateTime()->setTime(17, 58)],
-            [__DIR__ . '/../../graph/lueneburg6.png', self::createDateTime()->setTime(11, 9)],
-            [__DIR__ . '/../../graph/schneefernhaus1.png', self::createDateTime()->setTime(9, 50)],
-            [__DIR__ . '/../../graph/schneefernhaus2.png', self::createDateTime()->setTime(15, 10)],
+            [__DIR__.'/../../graph/boesel.png', self::createDateTime()->setTime(9, 3)],
+            [__DIR__.'/../../graph/friedrichshafen1.png', self::createDateTime()->setTime(10, 0)],
+            [__DIR__.'/../../graph/friedrichshafen2.png', self::createDateTime()->setTime(20, 58)],
+            [__DIR__.'/../../graph/hamburg1.png', self::createDateTime()->setTime(17, 50)],
+            [__DIR__.'/../../graph/hamburg2.png', self::createDateTime()->setTime(9, 54)],
+            [__DIR__.'/../../graph/lueneburg1.png', self::createDateTime()->setTime(18, 10)],
+            [__DIR__.'/../../graph/lueneburg2.png', self::createDateTime()->setTime(14, 9)],
+            [__DIR__.'/../../graph/lueneburg3.png', self::createDateTime()->setTime(15, 9)],
+            [__DIR__.'/../../graph/lueneburg4.png', self::createDateTime()->setTime(15, 0)],
+            [__DIR__.'/../../graph/lueneburg5.png', self::createDateTime()->setTime(17, 58)],
+            [__DIR__.'/../../graph/lueneburg6.png', self::createDateTime()->setTime(11, 9)],
+            [__DIR__.'/../../graph/schneefernhaus1.png', self::createDateTime()->setTime(9, 50)],
+            [__DIR__.'/../../graph/schneefernhaus2.png', self::createDateTime()->setTime(15, 10)],
         ];
     }
 
     public function testEmptyDataDateTimeFailure(): void
     {
         $imagine = new Imagine();
-        $image = $imagine->open(__DIR__ . '/../../graph/melpitz.png');
+        $image = $imagine->open(__DIR__.'/../../graph/melpitz.png');
 
         $currentDateTime = CurrentDateTime::calculate($image);
 

--- a/tests/Unit/Graph/HourRangeModelTest.php
+++ b/tests/Unit/Graph/HourRangeModelTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 

--- a/tests/Unit/Graph/HourRangeTest.php
+++ b/tests/Unit/Graph/HourRangeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -24,8 +26,8 @@ class HourRangeTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/hamburg1.png', 6, 21],
-            [__DIR__ . '/../../graph/lueneburg5.png', 7, 18],
+            [__DIR__.'/../../graph/hamburg1.png', 6, 21],
+            [__DIR__.'/../../graph/lueneburg5.png', 7, 18],
         ];
     }
 }

--- a/tests/Unit/Graph/MaintenanceTest.php
+++ b/tests/Unit/Graph/MaintenanceTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -21,10 +23,10 @@ class MaintenanceTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/sanktaugustin.png', true],
-            [__DIR__ . '/../../graph/hamburg3.png', true],
-            [__DIR__ . '/../../graph/lueneburg1.png', false],
-            [__DIR__ . '/../../graph/schneefernhaus2.png', false],
+            [__DIR__.'/../../graph/sanktaugustin.png', true],
+            [__DIR__.'/../../graph/hamburg3.png', true],
+            [__DIR__.'/../../graph/lueneburg1.png', false],
+            [__DIR__.'/../../graph/schneefernhaus2.png', false],
         ];
     }
 }

--- a/tests/Unit/Graph/MaxUvIndexTest.php
+++ b/tests/Unit/Graph/MaxUvIndexTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -21,9 +23,9 @@ class MaxUvIndexTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/hamburg1.png', 9],
-            [__DIR__ . '/../../graph/lueneburg1.png', 6],
-            [__DIR__ . '/../../graph/lueneburg5.png', 4],
+            [__DIR__.'/../../graph/hamburg1.png', 9],
+            [__DIR__.'/../../graph/lueneburg1.png', 6],
+            [__DIR__.'/../../graph/lueneburg5.png', 4],
         ];
     }
 }

--- a/tests/Unit/Graph/PointTest.php
+++ b/tests/Unit/Graph/PointTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -25,10 +27,10 @@ class PointTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/hamburg1.png', 472, 329],
-            [__DIR__ . '/../../graph/lueneburg1.png', 483, 426],
-            [__DIR__ . '/../../graph/lueneburg2.png', 350, 234],
-            [__DIR__ . '/../../graph/lueneburg3.png', 383, 261],
+            [__DIR__.'/../../graph/hamburg1.png', 472, 329],
+            [__DIR__.'/../../graph/lueneburg1.png', 483, 426],
+            [__DIR__.'/../../graph/lueneburg2.png', 350, 234],
+            [__DIR__.'/../../graph/lueneburg3.png', 383, 261],
         ];
     }
 
@@ -37,7 +39,7 @@ class PointTest extends TestCase
         $this->expectException(NoPointException::class);
 
         $imagine = new Imagine();
-        $image = $imagine->open(__DIR__ . '/../../graph/melpitz.png');
+        $image = $imagine->open(__DIR__.'/../../graph/melpitz.png');
 
         Point::detectCurrentPoint($image);
     }

--- a/tests/Unit/Graph/ScaleTest.php
+++ b/tests/Unit/Graph/ScaleTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -30,11 +32,11 @@ class ScaleTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/hamburg1.png', 20, 16],
-            [__DIR__ . '/../../graph/lueneburg1.png', 14, 16],
-            [__DIR__ . '/../../graph/lueneburg5.png', 10, 12],
-            [__DIR__ . '/../../graph/schneefernhaus1.png', 24, 16],
-            [__DIR__ . '/../../graph/schneefernhaus2.png', 24, 16],
+            [__DIR__.'/../../graph/hamburg1.png', 20, 16],
+            [__DIR__.'/../../graph/lueneburg1.png', 14, 16],
+            [__DIR__.'/../../graph/lueneburg5.png', 10, 12],
+            [__DIR__.'/../../graph/schneefernhaus1.png', 24, 16],
+            [__DIR__.'/../../graph/schneefernhaus2.png', 24, 16],
         ];
     }
 }

--- a/tests/Unit/Graph/StepSizeTest.php
+++ b/tests/Unit/Graph/StepSizeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Graph;
 
@@ -21,10 +23,10 @@ class StepSizeTest extends TestCase
     public static function graphFilenameProvider(): array
     {
         return [
-            [__DIR__ . '/../../graph/hamburg1.png', 21],
-            [__DIR__ . '/../../graph/lueneburg1.png', 32],
-            [__DIR__ . '/../../graph/lueneburg2.png', 21],
-            [__DIR__ . '/../../graph/lueneburg5.png', 48],
+            [__DIR__.'/../../graph/hamburg1.png', 21],
+            [__DIR__.'/../../graph/lueneburg1.png', 32],
+            [__DIR__.'/../../graph/lueneburg2.png', 21],
+            [__DIR__.'/../../graph/lueneburg5.png', 48],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- `friendsofphp/php-cs-fixer` als Dev-Abhängigkeit installiert
- Symfony-Ruleset konfiguriert in `.php-cs-fixer.dist.php`
- Initial-Formatierung aller 43 PHP-Dateien durchgeführt

## Test plan
- [x] Alle 62 Unit-Tests bestanden
- [x] PHPStan fehlerfrei

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)