### PR TITLE
liip/imagine-bundle Constraint auf ^2.17 aktualisieren

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.5",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "liip/imagine-bundle": "^2.12",
+        "liip/imagine-bundle": "^2.17",
         "luft-jetzt/luft-api-bundle": "0.8.1",
         "nesbot/carbon": "^3.6",
         "symfony/cache": "7.4.*",


### PR DESCRIPTION
## Summary
- Constraint von `^2.12` auf `^2.17` angehoben
- Version 2.17.1 war bereits durch das Symfony-Upgrade installiert

## Test plan
- [x] Alle 62 Unit-Tests bestanden

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)