### PR TITLE
luft-api-bundle nicht mehr auf exakte Version pinnen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "liip/imagine-bundle": "^2.17",
-        "luft-jetzt/luft-api-bundle": "0.8.1",
+        "luft-jetzt/luft-api-bundle": "^0.8.1",
         "nesbot/carbon": "^3.6",
         "symfony/cache": "7.4.*",
         "symfony/console": "7.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "154796ba50ea03668d9f0d14936202f0",
+    "content-hash": "bd81f7f5ea5f4705c6dff6a01d6d85cb",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",


### PR DESCRIPTION
## Summary
- Constraint von `0.8.1` auf `^0.8.1` geändert
- Erlaubt Patch-Updates (0.8.x) gemäß Semantic Versioning

## Test plan
- [x] Alle 62 Unit-Tests bestanden

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)