### PR TITLE
HttpClient und Cache per Dependency Injection bereitstellen

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,8 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        bind:
+            Symfony\Component\Cache\Adapter\AdapterInterface $stationCache: '@app.station_cache'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -20,5 +22,10 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
 
-    # add more service definitions when explicit configuration is needed
-    # please note that last definitions always *replace* previous ones
+    # Station cache as FilesystemAdapter
+    app.station_cache:
+        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+        arguments:
+            $namespace: 'station_cache'
+            $defaultLifetime: 604800 # 7 days
+            $directory: '%kernel.project_dir%/var/cache/'

--- a/src/Bfs/Cache/CacheInterface.php
+++ b/src/Bfs/Cache/CacheInterface.php
@@ -6,8 +6,5 @@ namespace App\Bfs\Cache;
 
 interface CacheInterface
 {
-    public const string CACHE_NAMESPACE = 'station_cache';
     public const string CACHE_KEY = 'station_list';
-    public const int CACHE_TTL = 60 * 60 * 24 * 7;
-    public const string CACHE_DIRECTORY = __DIR__.'/../../../var/cache/';
 }

--- a/src/Bfs/Fetcher/ValueFetcher.php
+++ b/src/Bfs/Fetcher/ValueFetcher.php
@@ -13,11 +13,15 @@ use App\Bfs\Graph\StepSize;
 use App\Bfs\Website\StationModel;
 use Caldera\LuftModel\Model\Value;
 use Imagine\Gd\Imagine;
-use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ValueFetcher implements ValueFetcherInterface
 {
     private ?\DateTime $now = null;
+
+    public function __construct(private readonly HttpClientInterface $httpClient)
+    {
+    }
 
     public function setNow(\DateTime $now): void
     {
@@ -71,8 +75,7 @@ class ValueFetcher implements ValueFetcherInterface
     protected function loadImageContent(string $url): string
     {
         if (str_starts_with($url, 'https://')) {
-            $httpClient = HttpClient::create();
-            $response = $httpClient->request('GET', $url);
+            $response = $this->httpClient->request('GET', $url);
 
             return $response->getContent();
         }

--- a/src/Bfs/Website/StationLinkExtractor.php
+++ b/src/Bfs/Website/StationLinkExtractor.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Bfs\Website;
 
 use Symfony\Component\DomCrawler\Crawler;
-use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class StationLinkExtractor implements StationLinkExtractorInterface
 {
+    public function __construct(private readonly HttpClientInterface $httpClient)
+    {
+    }
+
     public function parseStationLinks(): array
     {
         $htmlContent = $this->loadPageContent();
@@ -30,8 +34,7 @@ class StationLinkExtractor implements StationLinkExtractorInterface
 
     protected function loadPageContent(): string
     {
-        $httpClient = HttpClient::create();
-        $response = $httpClient->request('GET', self::PAGE_URL);
+        $response = $this->httpClient->request('GET', self::PAGE_URL);
 
         return $response->getContent();
     }

--- a/src/Bfs/Website/StationPageParser.php
+++ b/src/Bfs/Website/StationPageParser.php
@@ -6,11 +6,11 @@ namespace App\Bfs\Website;
 
 use App\Bfs\Coordinate\Converter;
 use Symfony\Component\DomCrawler\Crawler;
-use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class StationPageParser implements StationPageParserInterface
 {
-    public function __construct()
+    public function __construct(private readonly HttpClientInterface $httpClient)
     {
     }
 
@@ -39,8 +39,7 @@ class StationPageParser implements StationPageParserInterface
 
     protected function loadPageContent(string $url): string
     {
-        $httpClient = HttpClient::create();
-        $response = $httpClient->request('GET', $url);
+        $response = $this->httpClient->request('GET', $url);
 
         return $response->getContent();
     }

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -6,29 +6,26 @@ namespace App\Command;
 
 use App\Bfs\Cache\CacheInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
 
 abstract class AbstractCommand extends Command
 {
-    protected function createCache(): AdapterInterface
+    public function __construct(private readonly AdapterInterface $stationCache)
     {
-        return new FilesystemAdapter(CacheInterface::CACHE_NAMESPACE, CacheInterface::CACHE_TTL, CacheInterface::CACHE_DIRECTORY);
+        parent::__construct();
     }
 
     protected function getStationList(): array
     {
-        $cache = $this->createCache();
-        $item = $cache->getItem(CacheInterface::CACHE_KEY);
+        $item = $this->stationCache->getItem(CacheInterface::CACHE_KEY);
 
         return $item->get();
     }
 
     public function cacheStationList(array $stationList): void
     {
-        $cache = $this->createCache();
-        $cacheItem = $cache->getItem(CacheInterface::CACHE_KEY);
+        $cacheItem = $this->stationCache->getItem(CacheInterface::CACHE_KEY);
         $cacheItem->set($stationList);
-        $cache->save($cacheItem);
+        $this->stationCache->save($cacheItem);
     }
 }

--- a/src/Command/Luft/FetchCommand.php
+++ b/src/Command/Luft/FetchCommand.php
@@ -10,6 +10,7 @@ use App\Command\AbstractCommand;
 use Caldera\LuftApiBundle\Api\ValueApi;
 use Caldera\LuftModel\Model\Value;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,11 +25,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class FetchCommand extends AbstractCommand
 {
     public function __construct(
+        AdapterInterface $stationCache,
         private readonly ValueFetcherInterface $valueFetcher,
         private readonly ValueApi $valueApi,
         private readonly LoggerInterface $logger,
     ) {
-        parent::__construct();
+        parent::__construct($stationCache);
     }
 
     protected function configure(): void

--- a/src/Command/Station/LoadCommand.php
+++ b/src/Command/Station/LoadCommand.php
@@ -6,6 +6,7 @@ namespace App\Command\Station;
 
 use App\Command\AbstractCommand;
 use Caldera\LuftApiBundle\Api\StationApiInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,13 +15,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'luft:station:load',
-    description: 'Push chacged stations to luft api',
+    description: 'Push cached stations to luft api',
 )]
 class LoadCommand extends AbstractCommand
 {
-    public function __construct(private readonly StationApiInterface $stationApi)
-    {
-        parent::__construct();
+    public function __construct(
+        AdapterInterface $stationCache,
+        private readonly StationApiInterface $stationApi,
+    ) {
+        parent::__construct($stationCache);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/StationCache/SaveCommand.php
+++ b/src/Command/StationCache/SaveCommand.php
@@ -8,6 +8,7 @@ use App\Bfs\Station\Namer;
 use App\Bfs\Website\StationLinkExtractorInterface;
 use App\Bfs\Website\StationPageParserInterface;
 use App\Command\AbstractCommand;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,10 +22,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class SaveCommand extends AbstractCommand
 {
     public function __construct(
+        AdapterInterface $stationCache,
         private readonly StationLinkExtractorInterface $linkExtractor,
         private readonly StationPageParserInterface $pageParser,
     ) {
-        parent::__construct();
+        parent::__construct($stationCache);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/tests/Unit/Fetcher/ValueFetcherTest.php
+++ b/tests/Unit/Fetcher/ValueFetcherTest.php
@@ -9,9 +9,17 @@ use App\Bfs\Website\StationModel;
 use Caldera\LuftModel\Model\Value;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ValueFetcherTest extends TestCase
 {
+    private function createValueFetcher(): ValueFetcher
+    {
+        $httpClient = $this->createStub(HttpClientInterface::class);
+
+        return new ValueFetcher($httpClient);
+    }
+
     #[DataProvider('graphFilenameProvider')]
     public function testValueFetcher(string $currentImageUrl, float $expectedUvIndex, \DateTime $expectedDateTime, \DateTime $currentDateTime): void
     {
@@ -22,7 +30,7 @@ class ValueFetcherTest extends TestCase
             ->setValue($expectedUvIndex)
             ->setDateTime($expectedDateTime);
 
-        $valueFetcher = new ValueFetcher();
+        $valueFetcher = $this->createValueFetcher();
         $valueFetcher->setNow($currentDateTime);
 
         $stationModel = new StationModel();
@@ -115,7 +123,7 @@ class ValueFetcherTest extends TestCase
             ->setCurrentImageUrl($currentImageUrl)
             ->setStationCode('TEST123');
 
-        $valueFetcher = new ValueFetcher();
+        $valueFetcher = $this->createValueFetcher();
 
         $this->assertNull($valueFetcher->fromStation($stationModel));
     }
@@ -136,7 +144,7 @@ class ValueFetcherTest extends TestCase
             ->setCurrentImageUrl($currentImageUrl)
             ->setStationCode('TEST123');
 
-        $valueFetcher = new ValueFetcher();
+        $valueFetcher = $this->createValueFetcher();
 
         $this->assertNull($valueFetcher->fromStation($stationModel));
     }


### PR DESCRIPTION
## Summary
- `HttpClientInterface` per Constructor Injection in `ValueFetcher`, `StationPageParser` und `StationLinkExtractor`
- Cache per DI in `AbstractCommand` statt `new FilesystemAdapter()`
- `FilesystemAdapter` als Service in `services.yaml` konfiguriert
- Tests mit `HttpClientInterface`-Stub angepasst

## Test plan
- [x] Alle 79 Tests bestanden
- [x] PHPStan fehlerfrei
- [x] PHP-CS-Fixer clean

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)