### PR TITLE
[Hoch] SSRF/LFI in ValueFetcher::loadImageContent verhindern

### DIFF
--- a/src/Bfs/Fetcher/ValueFetcher.php
+++ b/src/Bfs/Fetcher/ValueFetcher.php
@@ -74,12 +74,27 @@ class ValueFetcher implements ValueFetcherInterface
 
     protected function loadImageContent(string $url): string
     {
-        if (str_starts_with($url, 'https://')) {
-            $response = $this->httpClient->request('GET', $url);
+        // Absolute HTTP(S)-URLs ausschliesslich ueber den HTTP-Client laden (mit Timeout)
+        // und nur fuer erlaubte Hosts. Verhindert SSRF und (via file_get_contents)
+        // file://, phar://, ftp:// gegen interne Ziele.
+        if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
+            $host = parse_url($url, PHP_URL_HOST);
+
+            if (!is_string($host) || !$this->isAllowedHost($host)) {
+                throw new \InvalidArgumentException(sprintf('Refusing to load image from disallowed host: %s', $url));
+            }
+
+            $response = $this->httpClient->request('GET', $url, ['timeout' => 10]);
 
             return $response->getContent();
         }
 
+        // Jedes andere URL-Schema (file://, phar://, ftp:// ...) ablehnen.
+        if (1 === preg_match('#^[a-zA-Z][a-zA-Z0-9+.\-]*://#', $url)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported URL scheme: %s', $url));
+        }
+
+        // Verbleibend: lokaler Dateipfad (z. B. Test-Fixtures / lokale Caches).
         $content = file_get_contents($url);
 
         if (false === $content) {
@@ -87,5 +102,12 @@ class ValueFetcher implements ValueFetcherInterface
         }
 
         return $content;
+    }
+
+    private function isAllowedHost(string $host): bool
+    {
+        $host = strtolower($host);
+
+        return 'bfs.de' === $host || str_ends_with($host, '.bfs.de');
     }
 }

--- a/tests/Unit/Fetcher/ValueFetcherTest.php
+++ b/tests/Unit/Fetcher/ValueFetcherTest.php
@@ -156,6 +156,33 @@ class ValueFetcherTest extends TestCase
         ];
     }
 
+    #[DataProvider('disallowedUrlProvider')]
+    public function testDisallowedUrlsAreRejected(string $currentImageUrl): void
+    {
+        $stationModel = new StationModel();
+        $stationModel
+            ->setCurrentImageUrl($currentImageUrl)
+            ->setStationCode('TEST123');
+
+        $valueFetcher = $this->createValueFetcher();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $valueFetcher->fromStation($stationModel);
+    }
+
+    public static function disallowedUrlProvider(): array
+    {
+        return [
+            'file scheme (LFI)' => ['file:///etc/passwd'],
+            'phar scheme' => ['phar:///tmp/evil.phar'],
+            'ftp scheme' => ['ftp://example.com/x.png'],
+            'SSRF cloud metadata' => ['http://169.254.169.254/latest/meta-data/'],
+            'SSRF localhost' => ['http://127.0.0.1:8080/x.png'],
+            'foreign host' => ['https://evil.example.com/x.png'],
+        ];
+    }
+
     private static function createDateTime(int $hour, int $minute): \DateTime
     {
         return (new \DateTime('now', new \DateTimeZone('Europe/Berlin')))->setTime($hour, $minute);


### PR DESCRIPTION
Behebt #54.

## Problem
`ValueFetcher::loadImageContent()` gab jede URL, die nicht mit `https://` begann, an `file_get_contents()`. Die URL stammt aus dem gescrapten `<img src>` der BFS-Stationsseite (`StationPageParser`), ist also nicht vertrauenswürdig. Damit waren möglich:
- `file:///etc/passwd` — lokaler Dateizugriff
- `phar://…` — potenzielle Object-Deserialization
- `ftp://…` und SSRF gegen interne Hosts (z. B. `http://169.254.169.254/…`)

## Lösung
- **http(s)-URLs** nur noch über den Symfony-HTTP-Client laden (mit `timeout: 10`) und **nur für erlaubte Hosts** (`bfs.de` / `*.bfs.de`) — blockt SSRF gegen interne/fremde Ziele.
- **Andere Schemata** (`file://`, `phar://`, `ftp://` …) werden mit `InvalidArgumentException` abgelehnt.
- **Schema-lose Strings** bleiben als lokaler Dateipfad zulässig (Test-Fixtures, lokale Caches). `file_get_contents` wird also nur noch für echte Dateipfade genutzt, nie für Remote-Wrapper.

Die legitimen Bild-URLs sind absolute `https://www.bfs.de/…`-Adressen (`StationLinkExtractorInterface::HOSTNAME`), daher deckt die Host-Allowlist den Normalbetrieb ab.

## Tests
6 zusätzliche Fälle (`file`/`phar`/`ftp`/Cloud-Metadaten/localhost/Fremdhost) in `ValueFetcherTest`. Gesamte Suite grün (93 Tests). Die vorhandenen Tests nutzen lokale Fixture-Pfade und laufen unverändert.

> Hinweis: Sollte BFS Bilder von einem anderen Host als `*.bfs.de` ausliefern, muss die Allowlist (`isAllowedHost`) entsprechend erweitert werden.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)