### PR TITLE
[Mittel] Härtung: HTTP-Timeout, defensives HTML-Parsing, APP_SECRET-Platzhalter

### DIFF
--- a/.env
+++ b/.env
@@ -16,5 +16,5 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_SECRET=607ddc43434ac4dd54a3ad9d3ae96062
+APP_SECRET=change_me_in_env_local
 ###< symfony/framework-bundle ###

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -3,6 +3,11 @@ framework:
     secret: '%env(APP_SECRET)%'
     #csrf_protection: true
 
+    http_client:
+        default_options:
+            timeout: 10
+            max_duration: 30
+
     # Note that the session will be started ONLY if you read or write from it.
     session: true
 

--- a/src/Bfs/Website/StationLinkExtractor.php
+++ b/src/Bfs/Website/StationLinkExtractor.php
@@ -18,7 +18,10 @@ class StationLinkExtractor implements StationLinkExtractorInterface
     {
         $htmlContent = $this->loadPageContent();
 
-        $crawler = new Crawler($htmlContent);
+        // Inhalt explizit als HTML parsen (kein Content-Sniffing), damit eine mit
+        // <?xml beginnende Antwort nie versehentlich den XML-Pfad triggert.
+        $crawler = new Crawler();
+        $crawler->addHtmlContent($htmlContent);
 
         $links = $crawler
             ->filter('#main #content ul li a')

--- a/src/Bfs/Website/StationPageParser.php
+++ b/src/Bfs/Website/StationPageParser.php
@@ -16,7 +16,10 @@ class StationPageParser implements StationPageParserInterface
 
     public function parse(string $url): StationModel
     {
-        $crawler = new Crawler($this->loadPageContent($url));
+        // Inhalt explizit als HTML parsen (kein Content-Sniffing), damit eine mit
+        // <?xml beginnende Antwort nie versehentlich den XML-Pfad triggert.
+        $crawler = new Crawler();
+        $crawler->addHtmlContent($this->loadPageContent($url));
         $station = new StationModel();
 
         $coordinateString = $crawler->filter('table tbody tr:nth-child(4) td:nth-child(2)')->html();


### PR DESCRIPTION
Adressiert den Härtungs-Teil von #55 (die SSRF/LFI-Lücke ist separat in #56; Dependency-Updates siehe Hinweis).

## Änderungen
- **`config/packages/framework.yaml`**: `http_client.default_options.timeout: 10` + `max_duration: 30` gegen hängende Requests beim Scrapen der BFS-Seiten.
- **`StationPageParser` / `StationLinkExtractor`**: Inhalt explizit via `addHtmlContent()` parsen statt `new Crawler($content)` (kein Content-Sniffing → eine `<?xml`-Antwort triggert nie versehentlich den XML-Pfad).
- **`.env`**: produktionsartiges `APP_SECRET` (`607ddc43…`) durch Platzhalter ersetzt. Der bisherige Wert galt als committet/kompromittiert; **er sollte rotiert werden** (echter Wert nur in `.env.local`/ENV).

## Verifikation
`php -l` ok, Test-Suite grün (87 Tests). Die bestehenden Tests parsen reale BFS-HTML-Fixtures und laufen unverändert.

## Hinweis (separat)
Die Symfony-Dependency-CVEs aus #55 erfordern denselben koordinierten Symfony-8.1-/PHPStan-Schritt wie luft-app#525.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)