### PR TITLE
[Hoch] Harden image loading against SSRF / local file disclosure (#54)

### DIFF
--- a/src/Bfs/Fetcher/ValueFetcher.php
+++ b/src/Bfs/Fetcher/ValueFetcher.php
@@ -17,6 +17,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ValueFetcher implements ValueFetcherInterface
 {
+    private const string ALLOWED_IMAGE_HOST = 'bfs.de';
+
     private ?\DateTime $now = null;
 
     public function __construct(private readonly HttpClientInterface $httpClient)
@@ -74,12 +76,32 @@ class ValueFetcher implements ValueFetcherInterface
 
     protected function loadImageContent(string $url): string
     {
-        if (str_starts_with($url, 'https://')) {
+        // A URL with a scheme is treated as a remote resource. Only http(s) to
+        // the trusted BfS host is allowed, and it is always fetched through the
+        // HTTP client. This prevents SSRF and local file disclosure via
+        // untrusted schemes (file://, phar://, data://, ...) or hosts scraped
+        // from the BfS station page. parse_url() cannot be trusted for scheme
+        // detection here (it returns false for e.g. "phar:///..."), so the
+        // scheme is extracted directly.
+        if (preg_match('#^([a-zA-Z][a-zA-Z0-9+.\-]*):#', $url, $matches)) {
+            $scheme = strtolower($matches[1]);
+
+            if ('http' !== $scheme && 'https' !== $scheme) {
+                throw new \RuntimeException(sprintf('Refusing to load image from disallowed URL scheme "%s": %s', $scheme, $url));
+            }
+
+            $host = parse_url($url, PHP_URL_HOST);
+
+            if (!is_string($host) || !self::isAllowedHost($host)) {
+                throw new \RuntimeException(sprintf('Refusing to load image from untrusted host: %s', $url));
+            }
+
             $response = $this->httpClient->request('GET', $url);
 
             return $response->getContent();
         }
 
+        // No scheme: a local filesystem path (used by tests and fixtures).
         $content = file_get_contents($url);
 
         if (false === $content) {
@@ -87,5 +109,12 @@ class ValueFetcher implements ValueFetcherInterface
         }
 
         return $content;
+    }
+
+    private static function isAllowedHost(string $host): bool
+    {
+        $host = strtolower($host);
+
+        return self::ALLOWED_IMAGE_HOST === $host || str_ends_with($host, '.'.self::ALLOWED_IMAGE_HOST);
     }
 }

--- a/tests/Unit/Fetcher/ValueFetcherTest.php
+++ b/tests/Unit/Fetcher/ValueFetcherTest.php
@@ -156,6 +156,33 @@ class ValueFetcherTest extends TestCase
         ];
     }
 
+    #[DataProvider('disallowedImageUrlProvider')]
+    public function testRejectsUntrustedImageUrl(string $imageUrl): void
+    {
+        $stationModel = new StationModel();
+        $stationModel
+            ->setCurrentImageUrl($imageUrl)
+            ->setStationCode('TEST123');
+
+        $valueFetcher = $this->createValueFetcher();
+
+        $this->expectException(\RuntimeException::class);
+
+        $valueFetcher->fromStation($stationModel);
+    }
+
+    public static function disallowedImageUrlProvider(): array
+    {
+        return [
+            'file scheme (local file disclosure)' => ['file:///etc/passwd'],
+            'phar scheme (object deserialization)' => ['phar:///tmp/evil.phar'],
+            'ftp scheme' => ['ftp://example.com/image.png'],
+            'internal host via http (SSRF)' => ['http://169.254.169.254/latest/meta-data/'],
+            'untrusted https host' => ['https://evil.example.com/image.png'],
+            'lookalike host' => ['https://bfs.de.evil.example.com/image.png'],
+        ];
+    }
+
     private static function createDateTime(int $hour, int $minute): \DateTime
     {
         return (new \DateTime('now', new \DateTimeZone('Europe/Berlin')))->setTime($hour, $minute);


### PR DESCRIPTION
> [!IMPORTANT]
> **CI is red due to pre-existing `main` breakage, not this change.** `main` fails two gates: the Tests job (missing phpunit `<source>` block → PHPUnit exits 1 under `--coverage-clover`) and the Composer Audit job (open advisories). Both are fixed by the foundational PR #66.
> **Merge #66 first, then rebase this branch onto `main` — CI goes green afterwards.**

## Summary
`ValueFetcher::loadImageContent()` loaded the graph image from a URL taken from the scraped `src` attribute of a BfS station page. Any URL not starting with `https://` was passed to `file_get_contents()`, enabling `file://`, `phar://`, `data://` and SSRF against internal hosts.

## Changes
- Detect a URL scheme robustly (regex, since `parse_url()` returns `false` for `phar:///…`).
- Reject every scheme except `http`/`https`.
- Restrict remote fetches to the `bfs.de` host family and always route them through the injected `HttpClientInterface`.
- Keep scheme-less filesystem paths working (used by the test fixtures).
- Add `testRejectsUntrustedImageUrl` covering `file://`, `phar://`, `ftp://`, an internal-IP `http://` URL, an untrusted `https` host and a `bfs.de.evil.example.com` lookalike host.

## Verification
- `vendor/bin/phpunit` green (93 tests, TZ=UTC and TZ=Europe/Berlin)
- `vendor/bin/phpstan analyse` (level 6) — no errors
- `vendor/bin/php-cs-fixer fix --dry-run` — clean

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)