### PR TITLE
[Hoch] Fix maintenance false-positive and cache-miss TypeError (#59)

### DIFF
--- a/src/Bfs/Graph/Maintenance.php
+++ b/src/Bfs/Graph/Maintenance.php
@@ -31,9 +31,13 @@ class Maintenance
     {
         $black = $image->palette()->color('000');
 
-        $edgeCounter = 0;
-
         foreach (self::POINT_LISTS as $pointList) {
+            // The counter must be evaluated per point list. A maintenance box is
+            // only present when a single list has all of its edges black;
+            // accumulating across lists produced false positives (e.g. 2 black
+            // edges in each list).
+            $edgeCounter = 0;
+
             foreach ($pointList as $point) {
                 $imagePoint = new ImaginePoint($point[0], $point[1]);
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -21,7 +21,13 @@ abstract class AbstractCommand extends Command
     {
         $item = $this->stationCache->getItem(CacheInterface::CACHE_KEY);
 
-        return $item->get();
+        if (!$item->isHit()) {
+            return [];
+        }
+
+        $stationList = $item->get();
+
+        return is_array($stationList) ? $stationList : [];
     }
 
     /** @param array<string, StationModel> $stationList */

--- a/tests/Unit/Graph/MaintenanceTest.php
+++ b/tests/Unit/Graph/MaintenanceTest.php
@@ -6,6 +6,9 @@ namespace App\Tests\Unit\Graph;
 
 use App\Bfs\Graph\Maintenance;
 use Imagine\Gd\Imagine;
+use Imagine\Image\Box;
+use Imagine\Image\Palette\RGB;
+use Imagine\Image\Point;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -28,5 +31,29 @@ class MaintenanceTest extends TestCase
             [__DIR__.'/../../graph/lueneburg1.png', false],
             [__DIR__.'/../../graph/schneefernhaus2.png', false],
         ];
+    }
+
+    /**
+     * A maintenance box is only present when a *single* point list has all four
+     * of its edges black. Two black edges in the first list plus two in the
+     * second must NOT be reported as maintenance (the counter has to reset per
+     * list).
+     */
+    public function testBlackEdgesSplitAcrossBothListsIsNotMaintenance(): void
+    {
+        $palette = new RGB();
+        $image = (new Imagine())->create(new Box(500, 200), $palette->color('#ffffff'));
+
+        $black = $palette->color('#000000');
+
+        // Two edges from the first point list ...
+        $image->draw()->dot(new Point(247, 80), $black);
+        $image->draw()->dot(new Point(417, 80), $black);
+        // ... and two from the second point list: four black edges in total,
+        // but never four within one list.
+        $image->draw()->dot(new Point(247, 120), $black);
+        $image->draw()->dot(new Point(417, 120), $black);
+
+        $this->assertFalse(Maintenance::isMaintenance($image));
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **CI is red due to pre-existing `main` breakage, not this change.** `main` fails two gates: the Tests job (missing phpunit `<source>` block → PHPUnit exits 1 under `--coverage-clover`) and the Composer Audit job (open advisories). Both are fixed by the foundational PR #66.
> **Merge #66 first, then rebase this branch onto `main` — CI goes green afterwards.**

## Summary
Addresses the still-open correctness bugs from the pipeline audit. Most of the issue's list is already fixed on `main` (Scale blue-channel comparison, `Europe/Berlin` timezone + int comparison in the hour-range guard, `NoPointException`-guarded point detection using `GraphDimensions` constants, targeted exception handling with per-station logging in `FetchCommand`). Two real bugs remained.

## Changes
- **`Maintenance::isMaintenance()`** — the `$edgeCounter` was shared across both `POINT_LISTS`, so 2 black edges in each list (4 total, but never 4 within one list) produced a false maintenance detection and the value was silently dropped. The counter now resets per point list. Verified against every fixture: the genuine maintenance images each carry all 4 black edges inside a single list (`sanktaugustin` → list 0, `hamburg3` → list 1), so real detection is unchanged. Added `testBlackEdgesSplitAcrossBothListsIsNotMaintenance` with a synthetic image.
- **`AbstractCommand::getStationList()`** — returned `$item->get()` (null on a cache miss) despite an `array` return type, causing a `TypeError` on the first run before any cache exists and making `FetchCommand`'s "No station list found in cache" guard unreachable. Now guards on `isHit()` and returns `[]` on a miss.

## Deliberately not implemented
- **`Namer` throwing on an unknown operator** (issue item 7). The existing `tests/Unit/Station/NamerTest::testUnknownOperatorReturnsEmptyString` deliberately codifies the current contract (`generate()` returns `''` for an unmapped operator). Changing `Namer` to throw would contradict that committed test/design, so it is left out. The `% 1000` collision concern is likewise left untouched to avoid changing that established behavior.

## Verification
- `vendor/bin/phpunit` green (88 tests, TZ=UTC and TZ=Europe/Berlin)
- `vendor/bin/phpstan analyse` (level 6) — no errors
- `vendor/bin/php-cs-fixer fix --dry-run` — clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)