### PR TITLE
[Mittel] Enable TLS certificate verification for the luft.jetzt API (#61)

### DIFF
--- a/config/packages/luft.yaml
+++ b/config/packages/luft.yaml
@@ -2,4 +2,5 @@ caldera_luftapi:
   api:
     hostname: luft.jetzt
     port: 443
-    verify: false
+    # TLS peer/host verification for all requests to the luft.jetzt API.
+    verify: true


### PR DESCRIPTION
> [!IMPORTANT]
> **CI is red due to pre-existing `main` breakage, not this change.** `main` fails two gates: the Tests job (missing phpunit `<source>` block → PHPUnit exits 1 under `--coverage-clover`) and the Composer Audit job (open advisories). Both are fixed by the foundational PR #66.
> **Merge #66 first, then rebase this branch onto `main` — CI goes green afterwards.**

## Summary
`config/packages/luft.yaml` set `verify: false`, so every `PUT https://luft.jetzt/api/value` ran without TLS peer/host verification, exposing the transfer to MITM. luft.jetzt has a valid certificate, so verification is set to `true`.

## Changes
- `config/packages/luft.yaml`: `verify: false` → `verify: true`.

## Deliberately not implemented
- The suggested `verify: '%env(bool:LUFT_API_VERIFY)%'` env-var toggle. The bundle casts the value to bool at container-compile time (`(bool) $config['api']['verify']` in `CalderaLuftApiExtension`), so an env placeholder is consumed as a constant and Symfony aborts the build with "Environment variables 'bool:LUFT_API_VERIFY' are never used". A plain secure boolean is the only value this bundle version accepts; a per-environment override would need a bundle change (tracked with the bundle upgrade).

## Verification
- `php bin/console cache:warmup` compiles the container.
- Compiled container instantiates `new ApiClient('luft.jetzt', 443, true)`, i.e. `verify_peer` and `verify_host` are enabled.
- `vendor/bin/phpunit` still green (87 tests).

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)